### PR TITLE
get bidder email from auth middleware

### DIFF
--- a/app/routes/auction.ts
+++ b/app/routes/auction.ts
@@ -116,15 +116,11 @@ class AuctionRoute {
     bid(req: express.Request, res: express.Response) {
         let bid = req.body.bid;
         const auctionId = req.params.auctionId;
-        const bidderEmail = req.body.bidderEmail;
+        const bidderEmail = res.locals.email;
 
         const validationErrors = [];
         if (!bid || typeof bid !== 'number') {
             validationErrors.push('missing or invalid attribute: bid');
-        }
-
-        if (!bidderEmail || typeof bidderEmail !== 'string') {
-            validationErrors.push('missing or invalid attribute: bidderEmail');
         }
 
         if (validationErrors.length > 0) {


### PR DESCRIPTION
We can grab email from the auth middleware as users need to be authenticated to bid, this way we don't need to pass it in the call or anything.